### PR TITLE
add support for "--cflags-only-other"

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1040,6 +1040,7 @@ GetOptions(
     'static' => \my $UseStatic,
     'cflags' => \my $PrintCflags,
     'cflags-only-I' => \my $PrintCflagsOnlyI,
+    'cflags-only-other' => \my $PrintCflagsOnlyOther,
     'exists' => \my $PrintExists,
     'atleast-version=s' => \my $AtLeastVersion,
     'exact-version=s'   => \my $ExactVersion,
@@ -1101,7 +1102,7 @@ if($SilenceErrors) {
     $quiet_errors = 1;
 }
 
-my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintLibsOnlyl || $PrintVersion);
+my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintCflagsOnlyOther || $PrintLibsOnlyl || $PrintVersion);
 
 if($WantFlags) {
     $quiet_errors = 0 unless $SilenceErrors;
@@ -1189,6 +1190,10 @@ if($PrintCflags) {
 
 if($PrintCflagsOnlyI) {
     @print_flags = grep /^-I/, $o->get_cflags;
+}
+
+if($PrintCflagsOnlyOther) {
+    @print_flags = grep /^-[^I]/, $o->get_cflags;
 }
 
 if($PrintLibs) {
@@ -1303,6 +1308,10 @@ List all know packages.
 =head4 --cflags-only-I
 
 Prints the -I part of "--cflags"
+
+=head4 --cflags-only-other
+
+Prints the parts of "--cflags" not covered by "--cflags-only-I".
 
 =head4 --modversion
 


### PR DESCRIPTION
Hello!

First of all, thank you for sharing the PkgConfig module with the world. It's been real helpful to me on systems that do not come with a native "pkg-config"!

Recently I have had to replace a pkg-config call with ppkg-config, but it failed due to the absence of the (somewhat new) flags "--cflags-only-other" and "--libs-only-other", so I went on and implemented them.

For your reviewing convenience I have separated them into two different pull requests. This is the first one, which adds support for the "--cflags-only-other" flag.

Hope it helps! Thanks again.