### PR TITLE
add support for "--libs-only-other" flag

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1036,6 +1036,7 @@ GetOptions(
     'libs' => \my $PrintLibs,
     'libs-only-L' => \my $PrintLibsOnlyL,
     'libs-only-l' => \my $PrintLibsOnlyl,
+    'libs-only-other' => \my $PrintLibsOnlyOther,
     'list-all' => \my $ListAll,
     'static' => \my $UseStatic,
     'cflags' => \my $PrintCflags,
@@ -1101,7 +1102,7 @@ if($SilenceErrors) {
     $quiet_errors = 1;
 }
 
-my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintLibsOnlyl || $PrintVersion);
+my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintLibsOnlyl || $PrintLibsOnlyOther || $PrintVersion);
 
 if($WantFlags) {
     $quiet_errors = 0 unless $SilenceErrors;
@@ -1193,6 +1194,10 @@ if($PrintCflagsOnlyI) {
 
 if($PrintLibs) {
     @print_flags = $o->get_ldflags;
+}
+
+if ($PrintLibsOnlyOther) {
+    @print_flags = grep /^-[^LRl]/, $o->get_ldflags;
 }
 
 # handle --libs-only-L and --libs-only-l but watch the case when
@@ -1291,6 +1296,11 @@ Prints -L/-R part of "--libs". It defines library search path but without librar
 =head4 --libs-only-l
 
 Prints the -l part of "--libs".
+
+=head4 --libs-only-other
+
+Prints the part of "--libs" not covered by "--libs-only-L"
+and "--libs-only-l", such as "--pthread".
 
 =head4 --list-all
 


### PR DESCRIPTION
Hello!

First of all, thank you for sharing the PkgConfig module with the world. It's been real helpful to me on systems that do not come with a native "pkg-config"!

Recently I have had to replace a pkg-config call with ppkg-config, but it failed due to the absence of the (somewhat new) flags "--cflags-only-other" and "--libs-only-other", so I went on and implemented them.

For your reviewing convenience I have separated them into two different pull requests. This is the second one, which adds support for the "--libs-only-other" flag.

Hope it helps! Thanks again.